### PR TITLE
Fix incorrect public_cidrs output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "private_cidrs" {
 }
 
 output "public_cidrs" {
-  value       = local.private_cidrs
+  value       = local.public_cidrs
   description = "The CIDR ranges for your public subnets"
 }
 


### PR DESCRIPTION
Public CIDRs output was set to local.private_cidrs, amended to local.public_cidrs